### PR TITLE
Add fast hopper protection

### DIFF
--- a/core/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
+++ b/core/src/main/java/com/griefcraft/listeners/LWCPlayerListener.java
@@ -84,6 +84,9 @@ public class LWCPlayerListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onMoveItem(InventoryMoveItemEvent event) {
+        if (plugin.getLWC().useFastHopperProtection() && event.getSource().getHolder() instanceof Hopper)
+            return;
+
         boolean result;
 
         // if the initiator is the same as the source it is a dropper i.e. depositing items
@@ -104,8 +107,6 @@ public class LWCPlayerListener implements Listener {
      * @param inventory
      */
     private boolean handleMoveItemEvent(Inventory initiator, Inventory inventory) {
-        LWC lwc = LWC.getInstance();
-
         if (inventory == null) {
             return false;
         }
@@ -137,6 +138,8 @@ public class LWCPlayerListener implements Listener {
         } catch (Exception e) {
             return false;
         }
+
+        LWC lwc = LWC.getInstance();
 
         // High-intensity zone: increase protection cache if it's full, otherwise
         // the database will be getting rammed

--- a/core/src/main/java/com/griefcraft/lwc/LWC.java
+++ b/core/src/main/java/com/griefcraft/lwc/LWC.java
@@ -205,10 +205,16 @@ public class LWC {
      */
     private final Map<String, String> protectionConfigurationCache = new HashMap<String, String>();
 
+    /**
+     * Whether fast-hopper-protection is enabled
+     */
+    private boolean fastHoppers;
+
     public LWC(LWCPlugin plugin) {
         this.plugin = plugin;
         LWC.instance = this;
         configuration = Configuration.load("core.yml");
+        fastHoppers = configuration.getBoolean("optional.fastHopperProtection", false);
         protectionCache = new ProtectionCache(this);
         backupManager = new BackupManager();
         moduleLoader = new ModuleLoader(this);
@@ -1896,6 +1902,7 @@ public class LWC {
         plugin.loadLocales();
         protectionConfigurationCache.clear();
         Configuration.reload();
+        fastHoppers = configuration.getBoolean("optional.fastHopperProtection", false);
         moduleLoader.dispatchEvent(new LWCReloadEvent());
     }
 
@@ -2043,4 +2050,11 @@ public class LWC {
         return !configuration.getBoolean("core.disableHistory", false);
     }
 
+    /**
+     * @return true if fast hopper protection is enabled
+     */
+    public boolean useFastHopperProtection()
+    {
+        return fastHoppers;
+    }
 }

--- a/core/src/main/resources/config/core.yml
+++ b/core/src/main/resources/config/core.yml
@@ -61,6 +61,7 @@ optional:
 
     # Blocks that cannot be placed around someone else's protection. This is most useful
     blacklistedBlocks:
+    - 154
     - 166
 
     # Players that are blocked from destroying any blocks protected by LWC. Mainly useful for MCPC
@@ -70,6 +71,11 @@ optional:
 
     # If protections limits will be enabled (defaults to unlimited protections)
     useProtectionLimits: true
+
+    # Disable protection checks for items being moved out of a hopper (destination doesn't matter)
+    # This applies to a hopper pushing items into a protected chest, or a hopper pulling from a
+    # protected hopper, but doesn't apply to a hopper pulling from a protected chest
+    fastHopperProtection: false
 
 # Database information for LWC
 database:
@@ -162,6 +168,8 @@ protections:
         chest:
             enabled: true
             autoRegister: private
+        trapped_chest:
+            enabled: true
         furnace:
             enabled: true
             autoRegister: private


### PR DESCRIPTION
Also enabled trapped chests for protection by default and added hoppers to the blacklist. Blacklisted blocks aren't allowed to be placed next to protected blocks that the placing player doesn't have access to.